### PR TITLE
1 of 2 changes to support bot replays in ggtracker#149

### DIFF
--- a/sc2reader/engine/plugins/context.py
+++ b/sc2reader/engine/plugins/context.py
@@ -63,7 +63,7 @@ class ContextLoader(object):
             self.logger.error("Other unit {0} not found".format(event.other_unit_id))
 
     def handleTargetUnitCommandEvent(self, event, replay):
-        if event.player is not None:
+        if event.player:
             self.last_target_ability_event[event.player.pid] = event
 
 

--- a/sc2reader/engine/plugins/context.py
+++ b/sc2reader/engine/plugins/context.py
@@ -63,7 +63,9 @@ class ContextLoader(object):
             self.logger.error("Other unit {0} not found".format(event.other_unit_id))
 
     def handleTargetUnitCommandEvent(self, event, replay):
-        self.last_target_ability_event[event.player.pid] = event
+        if event.player is not None:
+            self.last_target_ability_event[event.player.pid] = event
+
 
         if not replay.datapack:
             return


### PR DESCRIPTION
One of two fixes

This one corrects for the error we see here:

sc2reader/engine/plugins/context.py", line 66, in handleTargetUnitCommandEvent
    self.last_target_ability_event[event.player.pid] = event
AttributeError: 'NoneType' object has no attribute 'pid'